### PR TITLE
Python 3 requires bytes for md5 update.

### DIFF
--- a/suds/wsse.py
+++ b/suds/wsse.py
@@ -130,9 +130,9 @@ class UsernameToken(Token):
         """
         if text is None:
             s = []
-            s.append(self.username)
-            s.append(self.password)
-            s.append(Token.sysdate())
+            s.append(self.username.encode())
+            s.append(self.password.encode())
+            s.append(Token.sysdate().encode())
             m = md5()
             m.update(':'.join(s))
             self.nonce = m.hexdigest()


### PR DESCRIPTION
Doesn't break Python 2.7 either.